### PR TITLE
Change enum34 dependency to enum-compat and freeze coveralls at version 1.1 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 install:
   - pip install $DJANGO
   - pip install -r requirements-dev.txt
-  - pip install coveralls
+  - pip install coveralls==1.1  # travis pypy not compatible with later versions
   - pip freeze
 
 # command to run tests, e.g. python setup.py test

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 
 * João Neto - https://github.com/netjinho
 * Jorik Kraaikamp - https://github.com/JostCrow
+* Håken Lid - https://github.com/haakenlid

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cached-property
 Django>=1.8
-enum34
+enum-compat
 six


### PR DESCRIPTION
enum34 is not compatible with standard library enum since python 3.6, `enum-compat` solves this by not installing it unless python version < 3.4

#43 