### PR TITLE
Do not apply distinct if no regular filters have been found.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,4 +14,4 @@ Contributors
 * Håken Lid - https://github.com/haakenlid
 * Ryan O’Hara - https://github.com/ryan-copperleaf
 * webrunners - https://github.com/webrunners
-
+* Simone Pellizzari - https://github.com/simone6021

--- a/url_filter/backends/django.py
+++ b/url_filter/backends/django.py
@@ -113,7 +113,7 @@ class DjangoFilterBackend(BaseFilterBackend):
             queryset = queryset.exclude(**{lookup: value})
 
         to_many = self._is_any_to_many()
-        return queryset.distinct() if to_many else queryset
+        return queryset.distinct() if to_many and (include or exclude) else queryset
 
     def _is_any_to_many(self):
         return any(self._is_to_many(self.model, i.components) for i in self.regular_specs)


### PR DESCRIPTION
Queryset should not be modified if no filters are applied to it.  

The concrete use case is usage of url filter with [drf bulk](https://github.com/miki725/django-rest-framework-bulk) (which i did not remember that was yours, thanks also for that piece of code!), since the latter makes a security checks when bulk deleting: it will not execute if the queryset has not been filtered in order to avoid accidental deletion of all records.  
