### PR TITLE
Fixed bug in which DISTINCT clauses were forcibly removed from supplied  querysets

### DIFF
--- a/url_filter/backends/django.py
+++ b/url_filter/backends/django.py
@@ -113,7 +113,8 @@ class DjangoFilterBackend(BaseFilterBackend):
             queryset = queryset.exclude(**{lookup: value})
 
         to_many = self._is_any_to_many()
-        return queryset.distinct() if to_many and (include or exclude) else queryset
+        is_distinct = queryset.distinct()
+        return queryset.distinct() if (not is_distinct) and to_many and (include or exclude) else queryset
 
     def _is_any_to_many(self):
         return any(self._is_to_many(self.model, i.components) for i in self.regular_specs)


### PR DESCRIPTION
I was supplyin a queryset which was already distcint! And moreover I am using .distinct(field) in order to make a complex inetraction between url filters and Window functions work. Works a dream in fact except that url_filter was clobberig the necessary DISTINCT ON clause in my query. 

THis is where it happened and it was because it paid no heed to the existing status of the querie's distinct() setting. It neeed only apply distinct() if the caller has anot already applied on (not least as called knows what fields they need to distinguish on. 