### PR TITLE
Use CharField for regex validation to remove length limit

### DIFF
--- a/url_filter/filters.py
+++ b/url_filter/filters.py
@@ -29,6 +29,8 @@ LOOKUP_FIELD_OVERWRITES = {
     'day': forms.IntegerField(min_value=1, max_value=31),
     'month': forms.IntegerField(),
     'year': forms.IntegerField(min_value=0, max_value=9999),
+    'regex': forms.CharField(),
+    'iregex': forms.CharField(),
 }
 
 LOOKUP_CALLABLE_FROM_METHOD_REGEX = re.compile(


### PR DESCRIPTION
Given a Django Field with `max_length=15`, using a filter like `fieldname__iregex=(revisar|^revisar$)` will fail. The cause is that the corresponding form field is used for validation, and the length of the regex cannot be bigger than the field `max_length`.

This PR uses `LOOKUP_FIELD_OVERWRITES` to force validation of `regex` and `iregex` lookups using a `CharField`, overcoming the length limit.
